### PR TITLE
Add action to hide the theme warnings bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Current Features
-- Allows you to show/hide the title bar and the sidebar in the Shopify Admin
+- Allows you to show/hide the title bar, the theme warnings bar and the sidebar in the Shopify Admin
 - Changes the left sidebar colour to white in the Admin
 - Adds some extra info about each theme to the themes page in the Admin
 - Allows you to toggle some features on/off on the options page

--- a/extension.html
+++ b/extension.html
@@ -50,6 +50,7 @@
     <div class="seperator"></div>
 
     <div class="menu-option" data-action="titleBarToggle">Toggle Title Bar</div>
+    <div class="menu-option" data-action="themeWarningsToggle">Toggle Theme Warnings</div>
     <div class="menu-option" data-action="sidebarToggle">Toggle Sidebar</div>
 
     <div class="seperator"></div>

--- a/js/actions/theme-warnings-toggle.js
+++ b/js/actions/theme-warnings-toggle.js
@@ -1,0 +1,8 @@
+var $warningsBar = $('.file-errors-and-warnings');
+
+$warningsBar.animate({height:'toggle'}, {
+  duration: 350,
+  complete() {
+    window.dispatchEvent(new Event('resize'));
+  }
+});

--- a/js/background.js
+++ b/js/background.js
@@ -2,6 +2,10 @@ const ACTIONS = {
   titleBarToggle() {
     runScript('title-toggle');
   },
+  
+  themeWarningsToggle() {
+    runScript('theme-warnings-toggle');
+  },
 
   sidebarToggle() {
     runScript('sidebar-toggle');


### PR DESCRIPTION
@jgodson 

This adds an action to toggle the theme warnings/errors bar.

#### Video
https://screenshot.click/15-12-s3fab-fqkp5.mp4

#### Example of theme warnings bar

![https://screenshot.click/15-15-q2kak-q672e.jpg](https://screenshot.click/15-15-q2kak-q672e.jpg)

#### Extension menu items

![https://screenshot.click/15-17-8h5is-1nvnl.jpg](https://screenshot.click/15-17-8h5is-1nvnl.jpg)